### PR TITLE
Add library.properties metadata file

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,10 @@
+name=WT12Bluetooth
+version=0.0.0
+author=HF0
+maintainer=HF0
+sentence=A simple Bluetooth library for the Bluegiga WT12 module.
+paragraph=
+category=Communication
+url=https://github.com/HF0/bluetooth-wt12-for-arduino
+architectures=*
+includes=WT12Bluetooth.h


### PR DESCRIPTION
Libraries in the Arduino Library 1.5 format (source files under the src subfolder) are required to have a library.properties file in the root folder. If this file is not present the library is not recognized by the Arduino IDE.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#library-metadata